### PR TITLE
Fixed AnalysisScripts/mk_fitter.py when outputting to afs

### DIFF
--- a/AnalysisScripts/mk_fitter.py
+++ b/AnalysisScripts/mk_fitter.py
@@ -136,6 +136,7 @@ if __name__  == "__main__":
 	knownDomain = domain in knownDomains
 	if domain == "cern.ch":
 		atCern = True
+	mkdir="mkdir"
 	cp="cp -pv"
 	prependToStore=""
 	if not options.runIC:


### PR DESCRIPTION
AnalysisScripts/mk_fitter.py was failing when trying to use the output directory on AFS.

A line of code had been deleted when the code was restructured a few months back.
