### PR TITLE
Will now checkout HiggsAnalysis/CombinedLimit combination code 

### DIFF
--- a/extraTags
+++ b/extraTags
@@ -33,7 +33,13 @@ if [[ ! -d HiggsAnalysis/GBRLikelihood  ]]; then
 fi 
 cd HiggsAnalysis/GBRLikelihood
 scram b
+cd -
 
+if [[ ! -d HiggsAnalysis/CombinedLimit ]]; then
+  git clone https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit.git HiggsAnalysis/CombinedLimit
+fi
+cd HiggsAnalysis/CombinedLimit
+scram b
 
 cd -
 touch .extraTags


### PR DESCRIPTION
Added to extraTags so that Higgs combination code gets checkout and compiled when compiling globe.
