### PR TITLE
Runtime crash of reduction related to grid proxy

### DIFF
--- a/Reduction/run.sh
+++ b/Reduction/run.sh
@@ -63,7 +63,7 @@ fi
 
 if [[ -n $proxy ]]; then
     export X509_USER_PROXY=$(echo $proxy | awk -F: '{ print $2 }')
-    rsync -avP $proxy ${X509_USER_PROXY}
+    rsync -e "ssh -o StrictHostKeyChecking=no" -avP $proxy ${X509_USER_PROXY}
 fi
 
 source version.sh


### PR DESCRIPTION
If the grid proxy is setup on a machine not belonging to known_hosts, then local copy of the proxy fails, which in turn will crash file opening because no proxy is properly setup.

Fix is to avoid the "Are you sure you want to continue connecting” prompt at runtime.
