### PR TITLE
Scale R9 for cic only

### DIFF
--- a/GeneralFunctions.cc
+++ b/GeneralFunctions.cc
@@ -3304,7 +3304,7 @@ int LoopAll::PhotonCiCPFSelectionLevel( int photon_index, int vertex_index, std:
     float val_ecalisobad   = pho_pfiso_myphoton04[photon_index];
     float val_sieie        = pho_sieie[photon_index];
     float val_hoe          = pho_hoe[photon_index];
-    float val_r9           = pho_r9[photon_index];
+    float val_r9           = pho_r9_cic[photon_index];
     float val_conv         = pho_isconv[photon_index];
 
     float rhofacbad=0.23, rhofac=0.09;

--- a/LoopAll.cc
+++ b/LoopAll.cc
@@ -437,6 +437,7 @@ LoopAll::LoopAll(TTree *tree) :
   applyEcalIsoPresel = false;
   pfisoOffset=2.5;
   cicVersion="7TeV";
+  pho_r9_cic = &pho_r9[0];
 }
 
 // ------------------------------------------------------------------------------------

--- a/LoopAll.h
+++ b/LoopAll.h
@@ -127,6 +127,7 @@ class LoopAll {
   bool runZeeValidation;
   bool applyEcalIsoPresel;
   bool makeDummyTrees;
+  Float_t * pho_r9_cic;
   std::string cicVersion;
   bool usePFCiC;
   
@@ -625,7 +626,7 @@ Int_t PhotonR9Category(int photonindex, int n_r9cat=3, float r9boundary=0.94) {
   if(photonindex < 0) return -1;
   if(n_r9cat<2)return 0;
   int r9cat=0;
-  float r9 = pho_r9[photonindex];
+  float r9 = pho_r9_cic[photonindex];
   if(n_r9cat==3) {
     r9cat = (Int_t)(r9<0.94) + (r9<0.9);// 0, 1, or 2 (high r9 --> low r9)
   } else if(n_r9cat==2) {

--- a/PhotonAnalysis/interface/StatAnalysis.h
+++ b/PhotonAnalysis/interface/StatAnalysis.h
@@ -18,6 +18,8 @@
 #include <fstream>
 #include "math.h"
 
+#include "branchdef/Limits.h"
+
 // ------------------------------------------------------------------------------------
 class StatAnalysis : public PhotonAnalysis 
 {
@@ -81,7 +83,7 @@ class StatAnalysis : public PhotonAnalysis
 		     Float_t myVBFSubJPt, Int_t nVBFDijetJetCategories, bool isSyst, std::string name1);
 
     int nDataBins;  
-    bool scaleClusterShapes, scaleR9Only;
+    bool scaleClusterShapes, scaleR9Only, scaleR9ForCicOnly;
     bool dumpAscii, dumpMcAscii;
 
     std::vector<double> zeePtBinLowEdge, zeePtWeight;
@@ -133,6 +135,8 @@ class StatAnalysis : public PhotonAnalysis
     std::vector<float> smeared_pho_energy;
     std::vector<float> smeared_pho_r9;
     std::vector<float> smeared_pho_weight;
+    
+    Float_t corrected_pho_r9[MAX_PHOTONS];
 
     void  computeExclusiveCategory(LoopAll & l, int & category, std::pair<int,int> diphoton_index, float pt, float diphoBDT=1., bool mvaselection=false);
     void computeSpinCategory(LoopAll &l, int &category, TLorentzVector lead_p4, TLorentzVector sublead_p4);

--- a/PhotonAnalysis/src/StatAnalysis.cc
+++ b/PhotonAnalysis/src/StatAnalysis.cc
@@ -24,6 +24,7 @@ StatAnalysis::StatAnalysis()  :
     doSystematics = true;
     nVBFDijetJetCategories=2;
     scaleClusterShapes = true;
+    scaleR9ForCicOnly = false;
     dumpAscii = false;
     dumpMcAscii = false;
     unblind = false;
@@ -146,11 +147,10 @@ void StatAnalysis::Init(LoopAll& l)
     if( nR9Categories != 0 ) nInclusiveCategories_ *= nR9Categories;
     if( nPtCategories != 0 ) nInclusiveCategories_ *= nPtCategories;
 
-    // mva removed cp march 8
-    //if( useMVA ) nInclusiveCategories_ = nDiphoEventClasses;
-
-    // CP
-
+    // scale R9 for CiC only?
+    if( scaleR9ForCicOnly ) {
+	l.pho_r9_cic = &corrected_pho_r9[0];
+    }
     nPhotonCategories_ = nEtaCategories;
     if( nR9Categories != 0 ) nPhotonCategories_ *= nR9Categories;
 
@@ -1910,7 +1910,7 @@ void StatAnalysis::rescaleClusterVariables(LoopAll &l){
 
             if( scaleR9Only ) {
                 double R9_rescale = (l.pho_isEB[ipho]) ? 1.0048 : 1.00492 ;
-                l.pho_r9[ipho]*=R9_rescale;
+		l.pho_r9[ipho]*=R9_rescale;	   
             } else {
                 l.pho_r9[ipho]*=1.0035;
                 if (l.pho_isEB[ipho]){ l.pho_sieie[ipho] = (0.87*l.pho_sieie[ipho]) + 0.0011 ;}
@@ -1921,13 +1921,20 @@ void StatAnalysis::rescaleClusterVariables(LoopAll &l){
             }
 
         } else {
-            //2012 rescaling from here https://hypernews.cern.ch/HyperNews/CMS/get/higgs2g/752/1/1/2/1/3.html
-
-            if (l.pho_isEB[ipho]) {
-                l.pho_r9[ipho] = 1.0045*l.pho_r9[ipho] + 0.0010;
-            } else {
-                l.pho_r9[ipho] = 1.0086*l.pho_r9[ipho] - 0.0007;
-            }
+	    if( scaleR9ForCicOnly ) { 
+		if (l.pho_isEB[ipho]) {
+		    corrected_pho_r9[ipho] = 1.00793*l.pho_r9[ipho] + 0.00532538;
+		} else {
+		    corrected_pho_r9[ipho] = 1.00017*l.pho_r9[ipho] + 0.0016474;
+		}
+	    } else { 
+		//2012 rescaling from here https://hypernews.cern.ch/HyperNews/CMS/get/higgs2g/752/1/1/2/1/3.html
+		if (l.pho_isEB[ipho]) {
+		    l.pho_r9[ipho] = 1.0045*l.pho_r9[ipho] + 0.0010;
+		} else {
+		    l.pho_r9[ipho] = 1.0086*l.pho_r9[ipho] - 0.0007;
+		}
+	    }
             if( !scaleR9Only ) {
                 if (l.pho_isEB[ipho]) {
                     l.pho_s4ratio[ipho] = 1.01894*l.pho_s4ratio[ipho] - 0.01034;


### PR DESCRIPTION
Implementation R9 scaling from Matteo, applied only after preselection (i.e. for photon Id and categories)
It is activate via the flag 'scaleR9ForCicOnly' which is now is set by default to false.
