### PR TITLE
Lots of Fixes for ftest and Bias studies

### DIFF
--- a/BackgroundProfileFitting/interface/ProfileMultiplePdfs.h
+++ b/BackgroundProfileFitting/interface/ProfileMultiplePdfs.h
@@ -55,6 +55,8 @@ class ProfileMultiplePdfs {
     RooAbsPdf *getBestFitPdf(float var);
     double getGlobalMinNLL();
 
+    
+
   private:
     
     void addToResultMap(float var, float minNll, RooAbsPdf* pdf);
@@ -65,6 +67,7 @@ class ProfileMultiplePdfs {
     map<float,pair<float,RooAbsPdf*> > chosenPdfs;
     RooAbsPdf *bestFitPdf;
     double bestFitVal;
+    double bestFitErr;
     double globalMinNLL;
 
     static TGraph* getMinPoints(TGraph *graph);

--- a/BackgroundProfileFitting/scripts/make_hists_from_raw_files.py
+++ b/BackgroundProfileFitting/scripts/make_hists_from_raw_files.py
@@ -55,6 +55,7 @@ def makeHists(cat=0,meanB=50,meanL=-4.,meanH=4.,errB=50,errL=0.5,errH=1.5,pullB=
   TestFileFound = False
   test_file=0
   TFi = 0
+  print  dir+'/'+list_of_files[TFi]
   while not TestFileFound:
     test_file = r.TFile.Open(dir+'/'+list_of_files[TFi])
     try :
@@ -95,6 +96,7 @@ def makeHists(cat=0,meanB=50,meanL=-4.,meanH=4.,errB=50,errL=0.5,errH=1.5,pullB=
   histMap={}
   histErrMap={}
   histPullMap={}
+  histTypeMap={}
   graphCovMap={}
   counterCovMap={}
 
@@ -102,12 +104,14 @@ def makeHists(cat=0,meanB=50,meanL=-4.,meanH=4.,errB=50,errL=0.5,errH=1.5,pullB=
     histMap[type] = {}
     histErrMap[type] = {}
     histPullMap[type] = {}
+    histTypeMap[type] = {}
     graphCovMap[type] = {}
     counterCovMap[type] = {}
     for mod in truth_models:
       histMap[type][mod] = r.TH1F('%s_mu%s'%(mod,type),'%s_mu%s'%(mod,type),meanB,meanL,meanH)
       histErrMap[type][mod] = r.TH1F('%s_mu%sErr'%(mod,type),'%s_mu%sErr'%(mod,type),errB,errL,errH)
       histPullMap[type][mod] = r.TH1F('%s_mu%sPull'%(mod,type),'%s_mu%sPull'%(mod,type),pullB,pullL,pullH)
+      histTypeMap[type][mod] = {}
       graphCovMap[type][mod] = []
       counterCovMap[type][mod] = []
       for c, cov in enumerate(coverageValues):
@@ -138,13 +142,24 @@ def makeHists(cat=0,meanB=50,meanL=-4.,meanH=4.,errB=50,errL=0.5,errH=1.5,pullB=
       type = graph.GetName().split('Envelope')[0]
       mytype = util[type]
      
+      # first find which pdf gave the best fit
+      bfname = graph.GetTitle()
+      if bfname in histTypeMap[mytype][truth].keys():
+	histTypeMap[mytype][truth][bfname]+=1
+      else :
+	histTypeMap[mytype][truth][bfname]=1
+        
       muInfo = profiler.getMinAndErrorAsymmVec(graph,1.)
       muVal = muInfo.at(0)
       err_low = muInfo.at(1)
-      err_high = muInfo.at(2)
+      err_high  = muInfo.at(2)
       sym_err = (err_low+err_high)/2.
-      pull = profiler.getPull(graph,options.expectSignal)
 
+      if muVal<options.expectSignal: pull = (muVal-options.expectSignal)/err_high	
+      else: pull = (muVal-options.expectSignal)/err_low
+
+      #pull = profiler.getPull(graph,options.expectSignal) ## need to fit best fit and truth for this
+	
       #print truth, mytype, '%4.2f  %4.2f  %4.2f  %4.2f'%(muVal,err_low,err_high,sym_err)
       
       if muVal>=999. or sym_err>=999. or sym_err<0.001: continue
@@ -170,6 +185,18 @@ def makeHists(cat=0,meanB=50,meanL=-4.,meanH=4.,errB=50,errL=0.5,errH=1.5,pullB=
   for type, item in histPullMap.items():
     for truth, hist in item.items():
       hist.Write()
+  for type, item in histTypeMap.items():
+    for truth, hist in item.items():
+      ntypes = len(hist.keys())
+      htmp = r.TH1I('%s_mu%sType'%(truth,type),'%s_mu%sType'%(truth,type),ntypes,0,ntypes)
+      pdfbin = 0
+      for pdf in hist.keys(): 
+	htmp.SetBinContent(pdfbin+1,hist[pdf])
+	htmp.SetBinError(pdfbin+1,hist[pdf]**0.5)
+	htmp.GetXaxis().SetBinLabel(pdfbin+1,pdf)
+	pdfbin+=1
+      htmp.Write()
+     
   for type, item in counterCovMap.items():
     for truth, covArray in item.items():
       for c, covCounter in enumerate(covArray):

--- a/BackgroundProfileFitting/scripts/sub_coverage_jobs.py
+++ b/BackgroundProfileFitting/scripts/sub_coverage_jobs.py
@@ -90,22 +90,37 @@ if not options.readFromDat:
 else:
   f = open(options.readFromDat)
   configDict={}
-  for line in f.readlines():
-    if line.startswith('#') or line.startswith(' ') or line.startswith('\n'): continue
-    if not line.startswith('cat'):
-      #configDict[line.split('=')[0]] = line.split('=')[1].strip('\n')
-      setattr(options,line.split('=')[0],line.split('=')[1].strip('\n'))
+  cats = []
+  for linet in f.readlines():
+    if linet.startswith('#') or linet.startswith(' ') or linet.startswith('\n'): continue
+    if not linet.startswith('cat'):
+      #configDict[linet.split('=')[0]] = linet.split('=')[1].strip('\n')
+      setattr(options,linet.split('=')[0],linet.split('=')[1].strip('\n'))
     else:
-      lineConfig = line.split()
-      cat = int(lineConfig[0].split('=')[1])
-      injectmu = float(lineConfig[1].split('=')[1])
-      mlow = float(lineConfig[2].split('=')[1])
-      mhigh = float(lineConfig[3].split('=')[1])
-      mstep = float(lineConfig[4].split('=')[1])
-      injectmass = int(lineConfig[5].split('=')[1])
-      storage_dir = '%s/cat%d_mu%3.1f_mass%d'%(options.outerDir,cat,injectmu,injectmass)
-      if options.eosPath:
-        os.system('cmsMkdir %s/%s'%(options.eosPath,storage_dir))
-      os.system('mkdir -p %s'%storage_dir)
-      writeSubScript(cat,mlow,mhigh,mstep,storage_dir,injectmu,injectmass)
+     
+      if "cats=" in linet:
+        vlist = (linet.split("="))[1]
+        cats = [int(v) for v in vlist.split(",")] 
+        continue
+
+      linestouse = []
+
+      if "{cat}" in linet :
+	for c in cats: linestouse.append(linet.replace("{cat}","%d"%c))
+      
+      else: linestouse.append(linet)
+
+      for line in linestouse:
+       lineConfig = line.split()
+       cat = int(lineConfig[0].split('=')[1])
+       injectmu = float(lineConfig[1].split('=')[1])
+       mlow = float(lineConfig[2].split('=')[1])
+       mhigh = float(lineConfig[3].split('=')[1])
+       mstep = float(lineConfig[4].split('=')[1])
+       injectmass = int(lineConfig[5].split('=')[1])
+       storage_dir = '%s/cat%d_mu%3.1f_mass%d'%(options.outerDir,cat,injectmu,injectmass)
+       if options.eosPath:
+         os.system('cmsMkdir %s/%s'%(options.eosPath,storage_dir))
+       os.system('mkdir -p %s'%storage_dir)
+       writeSubScript(cat,mlow,mhigh,mstep,storage_dir,injectmu,injectmass)
 

--- a/BackgroundProfileFitting/scripts/subfTest.py
+++ b/BackgroundProfileFitting/scripts/subfTest.py
@@ -4,6 +4,8 @@ from optparse import OptionParser
 parser = OptionParser()
 parser.add_option("-i","--inputfilename",help="Data workspace file from Globe")
 parser.add_option("-o","--outDir",default="plots",help="Out directory for plots default: %default")
+parser.add_option("-O","--Options",default="",help="Add options")
+parser.add_option("-q","--queue",default="8nh",help="Batch queue")
 parser.add_option("-d","--datfile",default="dat/fTest.dat",help="dat file for the output")
 parser.add_option("-s","--saveMultiPdf",default="",help="Save a multipdf workspace as this name")
 parser.add_option("-c","--cats",type="int",help="Number of categories to run")
@@ -26,6 +28,7 @@ for cat in range(options.cats):
 	f.write('cd %s\n'%os.getcwd())
 	f.write('eval `scramv1 runtime -sh`\n')	
 	execLine = './bin/fTest -i %s -D %s --singleCat %d '%(options.inputfilename,options.outDir,cat)
+        execLine+=" %s "%options.Options
 	if options.unblind:
 		execLine += ' --unblind'
 	if options.verbose:
@@ -43,8 +46,8 @@ for cat in range(options.cats):
 	
 	os.system('chmod +x %s'%f.name)
 	if options.dryRun:
-		print 'bsub -q 8nh -o %s.log %s'%(os.path.abspath(f.name),os.path.abspath(f.name))
+		print 'bsub -q %s -o %s.log %s'%(options.queue,os.path.abspath(f.name),os.path.abspath(f.name))
 	else:
-		os.system('bsub -q 8nh -o %s.log %s'%(os.path.abspath(f.name),os.path.abspath(f.name)))
+		os.system('bsub -q %s -o %s.log %s'%(options.queue,os.path.abspath(f.name),os.path.abspath(f.name)))
 	
 	

--- a/BackgroundProfileFitting/src/PdfModelBuilder.cc
+++ b/BackgroundProfileFitting/src/PdfModelBuilder.cc
@@ -3,6 +3,7 @@
 #include "RooPlot.h"
 #include "RooBernstein.h"
 #include "RooChebychev.h"
+#include "RooPolynomial.h"
 #include "RooGenericPdf.h"
 #include "RooExponential.h"
 #include "RooPowerLaw.h"
@@ -83,7 +84,8 @@ RooAbsPdf* PdfModelBuilder::getChebychev(string prefix, int order){
     //prods.insert(pair<string,RooFormulaVar*>(name,form));
     coeffList->add(*params[name]);
   }
-  RooChebychev *cheb = new RooChebychev(prefix.c_str(),prefix.c_str(),*obs_var,*coeffList);
+  //RooChebychev *cheb = new RooChebychev(prefix.c_str(),prefix.c_str(),*obs_var,*coeffList);
+  RooPolynomial *cheb = new RooPolynomial(prefix.c_str(),prefix.c_str(),*obs_var,*coeffList);
   return cheb;
   //bkgPdfs.insert(pair<string,RooAbsPdf*>(bern->GetName(),bern));
 
@@ -102,7 +104,7 @@ RooAbsPdf* PdfModelBuilder::getBernstein(string prefix, int order){
     prods.insert(pair<string,RooFormulaVar*>(name,form));
     coeffList->add(*prods[name]);
   }
-  //RooBernsteinFast<(const int) order > *bern = new RooBernsteinFast<(const int) order >(prefix.c_str(),prefix.c_str(),*obs_var,*coeffList);
+  //RooBernstein *bern = new RooBernstein(prefix.c_str(),prefix.c_str(),*obs_var,*coeffList);
   if (order==1) {
 	RooBernsteinFast<1> *bern = new RooBernsteinFast<1>(prefix.c_str(),prefix.c_str(),*obs_var,*coeffList);
   	return bern;
@@ -127,6 +129,7 @@ RooAbsPdf* PdfModelBuilder::getBernstein(string prefix, int order){
   } else {
 	return NULL;
   }
+  //return bern;
   //bkgPdfs.insert(pair<string,RooAbsPdf*>(bern->GetName(),bern));
 
 }
@@ -234,13 +237,15 @@ RooAbsPdf* PdfModelBuilder::getPowerLawSingle(string prefix, int order){
     RooArgList *pows = new RooArgList();
     for (int i=1; i<=nfracs; i++){
       string name =  Form("%s_f%d",prefix.c_str(),i);
-      params.insert(pair<string,RooRealVar*>(name, new RooRealVar(name.c_str(),name.c_str(),0.9,0.000001,0.999999)));
+      params.insert(pair<string,RooRealVar*>(name, new RooRealVar(name.c_str(),name.c_str(),0.9-float(i-1)*1./nfracs,0.,1.)));
+      //params[name]->removeRange();
       fracs->add(*params[name]);
     }
     for (int i=1; i<=npows; i++){
       string name =  Form("%s_p%d",prefix.c_str(),i);
       string ename =  Form("%s_e%d",prefix.c_str(),i);
-      params.insert(pair<string,RooRealVar*>(name, new RooRealVar(name.c_str(),name.c_str(),TMath::Max(-10.,-1.*(i+1)),-10.,0.1)));
+      params.insert(pair<string,RooRealVar*>(name, new RooRealVar(name.c_str(),name.c_str(),TMath::Max(-20.,-1.*(i+1)),-10.,10.)));
+      //params[name]->removeRange();
       utilities.insert(pair<string,RooAbsPdf*>(ename, new RooPower(ename.c_str(),ename.c_str(),*obs_var,*params[name])));
       pows->add(*utilities[ename]);
     }
@@ -341,13 +346,13 @@ RooAbsPdf* PdfModelBuilder::getExponentialSingle(string prefix, int order){
     RooArgList *exps = new RooArgList();
     for (int i=1; i<=nfracs; i++){
       string name =  Form("%s_f%d",prefix.c_str(),i);
-      params.insert(pair<string,RooRealVar*>(name, new RooRealVar(name.c_str(),name.c_str(),0.5/nfracs,0.000001,0.999999)));
+      params.insert(pair<string,RooRealVar*>(name, new RooRealVar(name.c_str(),name.c_str(),0.9-float(i-1)*1./nfracs,0.0001,0.9999)));
       fracs->add(*params[name]);
     }
     for (int i=1; i<=nexps; i++){
       string name =  Form("%s_p%d",prefix.c_str(),i);
       string ename =  Form("%s_e%d",prefix.c_str(),i);
-      params.insert(pair<string,RooRealVar*>(name, new RooRealVar(name.c_str(),name.c_str(),TMath::Max(-2.,-0.04*(i+1)),-2.,-0.001)));
+      params.insert(pair<string,RooRealVar*>(name, new RooRealVar(name.c_str(),name.c_str(),TMath::Max(-2.,-0.04*(i+1)),-2.,1.5)));
       utilities.insert(pair<string,RooAbsPdf*>(ename, new RooExponential(ename.c_str(),ename.c_str(),*obs_var,*params[name])));
       exps->add(*utilities[ename]);
     }

--- a/BackgroundProfileFitting/src/ProfileMultiplePdfs.cc
+++ b/BackgroundProfileFitting/src/ProfileMultiplePdfs.cc
@@ -122,6 +122,7 @@ pair<double,map<string,TGraph*> > ProfileMultiplePdfs::profileLikelihood(RooAbsD
     if (2*nom->minNll()<globalMinNLL){
       globalMinNLL = 2*nom->minNll();
       bestFitVal = var->getVal();
+      bestFitErr = var->getError();
       bestFitPdf = pdf;
     }
   }
@@ -130,6 +131,14 @@ pair<double,map<string,TGraph*> > ProfileMultiplePdfs::profileLikelihood(RooAbsD
   cout << "\tmu  = " << bestFitVal << endl;
   cout << "\tpdf = " << bestFitPdf->GetName() << endl;
 
+  low  = bestFitVal-2.5*bestFitErr;
+  high = bestFitVal+2.5*bestFitErr;
+  std::vector<float> scanValues;
+  stepsize=stepsize*bestFitErr;
+  for (float v=low; v<(high+stepsize); v+=stepsize){
+    scanValues.push_back(v);	
+    if (v<bestFitVal && v+stepsize>bestFitVal) scanValues.push_back((float)bestFitVal);
+  }
   // now perform the scan
   cout << "Scanning...." << endl;
   for (map<string,pair<RooAbsPdf*,float> >::iterator m=listOfPdfs.begin(); m!=listOfPdfs.end(); m++) { 
@@ -137,7 +146,8 @@ pair<double,map<string,TGraph*> > ProfileMultiplePdfs::profileLikelihood(RooAbsD
     cout << "\t pdf " << distance(listOfPdfs.begin(),m) << "/" << listOfPdfs.size() << " (" << pdf->GetName() << ")" << endl;
     TGraph *thisNLL = new TGraph();
     int p=0;
-    for (float v=low; v<(high+stepsize); v+=stepsize){
+    for (std::vector<float>::iterator vit = scanValues.begin();vit!=scanValues.end();vit++){
+      float v = *vit;
       cout << Form("\t%5.1f%%\r",100.*(v-low)/(high-low)) << flush;
       RooArgSet *params = (RooArgSet*)pdf->getParameters(*var);
       setValues(mapOfValues,params);
@@ -177,6 +187,7 @@ pair<double,map<string,TGraph*> > ProfileMultiplePdfs::computeEnvelope(pair<doub
   }
   // now find envelope and apply correction
   float globalMin=1.e8;
+  std::string bestFitPdf;
   for (int p=0; p<npoints; p++){
     float minPoint=1.e8;
     double x,y;
@@ -193,9 +204,13 @@ pair<double,map<string,TGraph*> > ProfileMultiplePdfs::computeEnvelope(pair<doub
       if (valWithPenalty<minPoint){
         minPoint=valWithPenalty;
         //envelopeNLL->SetPoint(p,x,valWithPenalty);
-        if (minPoint<globalMin) globalMin=minPoint;
+        if (minPoint<globalMin) {
+		globalMin=minPoint;
+		bestFitPdf=mIt->first;
+	}
       }
       correctedMinNlls[mIt->first]->SetPoint(p,x,valWithPenalty);
+      correctedMinNlls[mIt->first]->SetTitle((mIt->first).c_str());
       //mIt->second->SetPoint(p,x,valWithPenalty);
     }
   }
@@ -238,6 +253,8 @@ pair<double,map<string,TGraph*> > ProfileMultiplePdfs::computeEnvelope(pair<doub
   }
   */
   envelopeNLL->SetName(name.c_str());
+  envelopeNLL->SetTitle(bestFitPdf.c_str());
+	
   correctedMinNlls.insert(pair<string,TGraph*>("envelope",envelopeNLL));
   return pair<double,map<string,TGraph*> >(envelopeMin,correctedMinNlls);
 
@@ -259,6 +276,7 @@ map<string,TGraph*> ProfileMultiplePdfs::profileLikelihoodEnvelope(RooAbsData *d
     if (2*nom->minNll()+penalty<globalMinNLL){
       globalMinNLL = 2*nom->minNll()+penalty;
       bestFitVal = var->getVal();
+      bestFitErr = var->getError();
       bestFitPdf = pdf;
     }
   }
@@ -266,13 +284,23 @@ map<string,TGraph*> ProfileMultiplePdfs::profileLikelihoodEnvelope(RooAbsData *d
   cout << "\tnll = " << globalMinNLL << endl;
   cout << "\tmu  = " << bestFitVal << endl;
   cout << "\tpdf = " << bestFitPdf->GetName() << endl;
+
+  low  = bestFitVal-2.5*bestFitErr;
+  high = bestFitVal+2.5*bestFitErr;
+  std::vector<float> scanValues;
+  stepsize=stepsize*bestFitErr;
+  for (float v=low; v<(high+stepsize); v+=stepsize){
+    scanValues.push_back(v);
+    if (v<bestFitVal && v+stepsize>bestFitVal) scanValues.push_back((float)bestFitVal);
+  }
   // now perform the scan
   for (map<string,pair<RooAbsPdf*,float> >::iterator m=listOfPdfs.begin(); m!=listOfPdfs.end(); m++) { 
     RooAbsPdf *pdf = m->second.first;
     float penalty = m->second.second;
     TGraph *thisNLL = new TGraph();
     int p=0;
-    for (float v=low; v<high; v+=stepsize){
+    for (std::vector<float>::iterator vit = scanValues.begin();vit!=scanValues.end();vit++){
+      float v = *vit;
       var->setConstant(false);
       var->setVal(v);
       var->setConstant(true);
@@ -289,7 +317,8 @@ map<string,TGraph*> ProfileMultiplePdfs::profileLikelihoodEnvelope(RooAbsData *d
     minNlls.insert(pair<string,TGraph*>(thisNLL->GetName(),thisNLL));
   }
   int p=0;
-  for (float v=low; v<high; v+=stepsize){
+  for (std::vector<float>::iterator vit = scanValues.begin();vit!=scanValues.end();vit++){
+    float v = *vit;
     float minPoint=1.e8;
     for (map<string,TGraph*>::iterator mIt=minNlls.begin(); mIt!=minNlls.end(); mIt++){
       if (mIt->second->Eval(v)<minPoint){
@@ -754,7 +783,7 @@ double ProfileMultiplePdfs::getPull(TGraph *nll, float trueVal, float stepsize, 
 
   double factor=1.;
   if (minP.first<trueVal) factor=-1.;
-  
+  if (fabs(minP.first-trueVal)<=2*stepsize )return 0;
   return TMath::Sqrt(truthNll-bestFitNll)*factor;
 
 }


### PR DESCRIPTION
Squashed commit of the following:

commit a0f34ab311ab9c31dfb89dc110eb3cdcd935b6ed
Author: nick n.c.k.wardle@googlemail.com
Date:   Thu Nov 28 10:16:18 2013 +0100

```
removed removeRange
```

commit dc23dd903602fa49b97c7a21ee6395cff4282873
Author: nick n.c.k.wardle@googlemail.com
Date:   Thu Nov 28 10:12:41 2013 +0100

```
RooFit bug if using removeRange
```

commit 039d052f231d92090ea96abce6bd68a55a779770
Author: nick n.c.k.wardle@googlemail.com
Date:   Thu Nov 28 10:02:49 2013 +0100

```
Add injected mu to output plot names
```

commit 8616bec5e244ef1b4bfee1efbfeeb6bf2be50c18
Author: nick n.c.k.wardle@googlemail.com
Date:   Wed Nov 27 18:29:10 2013 +0100

```
Lots of aesthetics for Bias studies
add record of best fitting pdf to outputs
```

commit b5a4d8db2096ac704652aeb174f84d4d0c0c05aa
Author: nick n.c.k.wardle@googlemail.com
Date:   Wed Nov 27 17:59:50 2013 +0100

```
fTest submission script accepts -q option for batch submission
```

commit 3c5c2c5ff29577e9b5d6b4767d89d4a1899b4841
Author: nick n.c.k.wardle@googlemail.com
Date:   Wed Nov 27 17:21:07 2013 +0100

```
additional iterations for choosing best fitting pdf also
```

commit 08d7fc1e411be652f2b37ac9c05aace74ff62dc4
Author: nick n.c.k.wardle@googlemail.com
Date:   Wed Nov 27 15:43:59 2013 +0100

```
Iterate fit until status is good otherwise spit out a warning
```

commit 573b99bec67fbba768a019199e7782da21898207
Author: nick n.c.k.wardle@googlemail.com
Date:   Tue Nov 26 23:37:40 2013 +0100

```
More usage of cats= keyword (picked up with {cat})
```

commit 1592784051b7e093e22f8d5385cc4868eea5f81d
Author: nick n.c.k.wardle@googlemail.com
Date:   Tue Nov 26 01:08:26 2013 +0100

```
Merging submission can now take special dat file with {cat} keywords
```

commit 7f404a1b6766fd13bf18cc3acea89976c8c0d9d9
Author: nick n.c.k.wardle@googlemail.com
Date:   Tue Nov 26 00:06:17 2013 +0100

```
Smarter choice for scanning based on where best fit is
always includ best fit as one of the points to scan
```

commit 3244cebc498618cfa87cf9c968264fe52d5f9993
Author: nick n.c.k.wardle@googlemail.com
Date:   Sat Nov 23 21:36:32 2013 +0100

```
Fix for parameter names in construction of RooMultiPdf (allows for 7+8TeV combinations)
```

commit 0bfefe2e3b213f6bfcc74dcbd0e356a25be23469
Author: nick n.c.k.wardle@googlemail.com
Date:   Fri Nov 22 14:20:39 2013 +0100

```
Multipdf plots now cycle through MultiPdf (since order doesnt matter now from maps) when plotting.
Need to re-fit each pdf since only the best fit pdf will look right
```

commit e2375b21ea590f2efbfb1a643e529bc924727b6d
Author: nick n.c.k.wardle@googlemail.com
Date:   Fri Nov 22 11:47:12 2013 +0100

```
Putting toys back for GOF test in low stat categories
```

commit 41fe59aecbd212603cd21828faa997408196861f
Author: nick n.c.k.wardle@googlemail.com
Date:   Fri Nov 22 11:15:26 2013 +0100

```
Adding option string to subfTest.py submission script
```

commit 919acf0348a192335a281b9a75c55d6414a8be05
Author: nick n.c.k.wardle@googlemail.com
Date:   Fri Nov 22 10:07:56 2013 +0100

```
Add iterative fit for fTest toys to improve status
```

commit 81e27ba4e3b1e45b47a8ef4b162c5e91594252d0
Author: nick n.c.k.wardle@googlemail.com
Date:   Wed Nov 20 21:56:22 2013 +0100

```
Shouldnt delete data in call for GOF test
```
