### PR TITLE
Fixed bug in computation of non-stocastic smearings.

### DIFF
--- a/EnergySmearer.cc
+++ b/EnergySmearer.cc
@@ -129,7 +129,7 @@ float EnergySmearer::getSmearingSigma(const energySmearingParameters & myParamet
   }
   smearing_sigma           += syst_shift * err_sigma;
   smearing_stocastic_sigma += syst_shift * smearing_stocastic_sigma_error;
-  if( ipivot != myParameters.smearing_stocastic_pivot.end() ) {
+  if( ipivot != myParameters.smearing_stocastic_pivot.end() && ipivot->second > 0. ) {
 	  float phi = std::max((float)0.,std::min((float)(TMath::Pi()*0.5),smearing_stocastic_sigma));
 	  float rho = smearing_sigma;
 	  smearing_stocastic_sigma = rho*ipivot->second*cos(phi);


### PR DESCRIPTION
Protect againsto sqrt(<ET>) = 0
