### PR TITLE
Fix systmaterial datfiles

### DIFF
--- a/AnalysisScripts/common/systs_settings_material.dat
+++ b/AnalysisScripts/common/systs_settings_material.dat
@@ -5,10 +5,11 @@ doEresolSyst=0
 doKFactorSyst=0
 doPdfWeightSyst=0
 doPhotonIdEffSyst=0
-doPhotonMvaIdSyst=0
+#MVA
+#doPhotonMvaIdSyst=0
 doPtSpinSyst=0
 doR9Syst=0
-doRegressionSyst=0
+#doRegressionSyst=0
 doStocasticSmearingSyst=0
 doSystematics=0
 doTriggerEffSyst=0

--- a/AnalysisScripts/massfac_mva_binned/datafiles_massfacmva_legacy_7TeV_systs_material.dat
+++ b/AnalysisScripts/massfac_mva_binned/datafiles_massfacmva_legacy_7TeV_systs_material.dat
@@ -19,6 +19,6 @@ inputBranches TTVH_analysis_input.dat
 treevariables massfac_mva_binned/fullmvatrees.dat massfac_mva_binned/treevariables_optree.dat
 
 
-analyzer MassFactorizedMvaAnalysis photonanalysis.dat analysis_settings.dat jun21rereco_7TeV/analysis_settings.dat massfactorizedmvaanalysis.dat jun21rereco_7TeV/massfactorizedmvaanalysis.dat systs_settings_material.dat
+analyzer MassFactorizedMvaAnalysis photonanalysis.dat analysis_settings.dat jun21rereco_7TeV/analysis_settings.dat massfactorizedmvaanalysis.dat jun21rereco_7TeV/massfactorizedmvaanalysis.dat systs_settings_material.dat systs_settings_material_mva.dat
 #systRange=1 sigPointsToBook=125 splitEscaleSyst=1 splitEresolSyst=1
 

--- a/AnalysisScripts/massfac_mva_binned/datafiles_massfacmva_legacy_systs_material.dat
+++ b/AnalysisScripts/massfac_mva_binned/datafiles_massfacmva_legacy_systs_material.dat
@@ -29,5 +29,5 @@ inputBranches TTVH_analysis_input.dat
 ##   analyzer <class_name> <config_file>
 ##
 ## analyzer PhotonAnalysis photonanalysis.dat
-analyzer MassFactorizedMvaAnalysis photonanalysis.dat analysis_settings.dat massfactorizedmvaanalysis.dat systs_settings_material.dat 
+analyzer MassFactorizedMvaAnalysis photonanalysis.dat analysis_settings.dat massfactorizedmvaanalysis.dat systs_settings_material.dat  systs_settings_material_mva.dat
 ## doFullMvaFinalTree=1

--- a/AnalysisScripts/massfac_mva_binned/systs_settings_material_mva.dat
+++ b/AnalysisScripts/massfac_mva_binned/systs_settings_material_mva.dat
@@ -1,0 +1,3 @@
+#MVA
+doPhotonMvaIdSyst=0
+doRegressionSyst=0


### PR DESCRIPTION
StatAnalysis does not have attributes specific of mva, therefore this switch off should go in a separate dat file.
